### PR TITLE
Add file picker and editing features

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,12 +1,46 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var text: String = ""
+    @State private var selectedURL: URL?
+    @State private var showPicker: Bool = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundColor(.accentColor)
-            Text("Hello, world!")
+        VStack(alignment: .leading) {
+            HStack {
+                Button("Open File") {
+                    showPicker = true
+                }
+                Spacer()
+                Button("Save") {
+                    saveText()
+                }
+                .disabled(selectedURL == nil)
+            }
+            .padding()
+
+            TextEditor(text: $text)
+                .border(Color.gray)
+                .padding()
         }
+        .sheet(isPresented: $showPicker) {
+            FilePicker { url in
+                selectedURL = url
+                loadText(from: url)
+                showPicker = false
+            }
+        }
+    }
+
+    private func loadText(from url: URL) {
+        if let data = try? Data(contentsOf: url),
+           let str = String(data: data, encoding: .utf8) {
+            text = str
+        }
+    }
+
+    private func saveText() {
+        guard let url = selectedURL else { return }
+        try? text.write(to: url, atomically: true, encoding: .utf8)
     }
 }

--- a/FilePicker.swift
+++ b/FilePicker.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct FilePicker: UIViewControllerRepresentable {
+    var onPick: (URL) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPick: onPick)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let markdown = UTType(filenameExtension: "md")!
+        let textType = UTType.plainText
+        let controller = UIDocumentPickerViewController(forOpeningContentTypes: [markdown, textType], asCopy: false)
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let onPick: (URL) -> Void
+
+        init(onPick: @escaping (URL) -> Void) {
+            self.onPick = onPick
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            onPick(url)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `FilePicker` to present a UIDocumentPicker limited to `.md` and `.txt`
- update `ContentView` with file open button, editable text view, and save button

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_b_68406109539483239bd5db644adaa383