### PR TITLE
Add markdown help panel

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -5,6 +5,17 @@ struct ContentView: View {
     @State private var selectedURL: URL?
     @State private var showPicker: Bool = false
     @State private var isEditing: Bool = false
+    @State private var showHelp: Bool = false
+    private let helpText: String
+
+    init() {
+        if let url = Bundle.main.url(forResource: "markdown-examples", withExtension: "txt"),
+           let contents = try? String(contentsOf: url) {
+            self.helpText = contents
+        } else {
+            self.helpText = ""
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -16,7 +27,14 @@ struct ContentView: View {
                     Toggle("", isOn: $isEditing)
                         .disabled(selectedURL == nil)
                 }
-                /*                
+                if isEditing {
+                    Button("Help") {
+                        withAnimation {
+                            showHelp.toggle()
+                        }
+                    }
+                }
+                /*
                 Button("Save") {
                     saveText()
                 }
@@ -26,9 +44,25 @@ struct ContentView: View {
             .padding()
 
             if isEditing {
-                TextEditor(text: $text)
-                    .border(Color.gray)
-                    .padding()
+                GeometryReader { geo in
+                    HStack(spacing: 0) {
+                        TextEditor(text: $text)
+                            .frame(width: showHelp ? geo.size.width * 2/3 : geo.size.width)
+                            .border(Color.gray)
+                        if showHelp {
+                            ScrollView {
+                                Text(helpText)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding()
+                            }
+                            .frame(width: geo.size.width * 1/3)
+                            .border(Color.gray)
+                            .transition(.move(edge: .trailing))
+                        }
+                    }
+                    .animation(.default, value: showHelp)
+                }
+                .padding()
             } else {
                 ScrollView {
                     // From Marco Eidinger blog

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,9 @@ let package = Package(
         .executableTarget(
             name: "AppModule",
             path: ".",
+            resources: [
+                .process("Resources")
+            ],
             swiftSettings: [
                 .enableUpcomingFeature("BareSlashRegexLiterals")
             ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # GemText-variant
 Testing flow 2 for functional prototyping
 
+This variant shows a text editor with a Help panel. The panel reads from
+`Resources/markdown-examples.txt` and slides in from the right while editing.
+
 Last updated 3 p.m.

--- a/Resources/markdown-examples.txt
+++ b/Resources/markdown-examples.txt
@@ -1,0 +1,3 @@
+**bold**  -  **two asterisks**
+*italic*  -  *one asterisk*
+`code`    -  `backticks`


### PR DESCRIPTION
## Summary
- show Help button during editing
- slide-in markdown Help panel
- load help text from bundle resource

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_6840aafd51248323b9d6f3c6a2959318