### PR TITLE
Add Info.plist with export compliance

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>GemText Approach 2</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add a new `Info.plist` file for the iOS app
- declare `ITSAppUsesNonExemptEncryption` as false to indicate no non-exempt encryption

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_6840ad90f2448323b7f4be0c36afebe5