### PR TITLE
Fix deprecated Swift calls

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
 
     init() {
         if let url = Bundle.main.url(forResource: "markdown-examples", withExtension: "txt"),
-           let contents = try? String(contentsOf: url) {
+           let contents = try? String(contentsOf: url, encoding: .utf8) {
             self.helpText = contents
         } else {
             self.helpText = ""
@@ -87,7 +87,7 @@ struct ContentView: View {
                 showPicker = false
             }
         }
-        .onChange(of: isEditing) { editing in
+        .onChange(of: isEditing) { _, editing in
             if editing == false {
                 saveText()
                 if let url = selectedURL {


### PR DESCRIPTION
## Summary
- follow the latest Swift APIs
- update `String(contentsOf:)` to specify `.utf8`
- use the new two-parameter version of `onChange`

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_6840ae16fc4c8323a9fc486aac14c9b5