### PR TITLE
Apply dark mode and editing border

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -86,6 +86,13 @@ struct ContentView: View {
                 .padding()
             }
         }
+        .padding()
+        .background(Color.black)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isEditing ? Color.yellow : Color.clear, lineWidth: 1)
+        )
         .sheet(isPresented: $showPicker) {
             FilePicker { url in
                 selectedURL = url

--- a/MyApp.swift
+++ b/MyApp.swift
@@ -5,6 +5,7 @@ struct MyApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .preferredColorScheme(.dark)
         }
     }
 }


### PR DESCRIPTION
## Summary
- force dark color scheme
- show yellow border while editing

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_6841ab6c37548323a268135d3ac41d26