### PR TITLE
Display file name in toolbar

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -27,7 +27,14 @@ struct ContentView: View {
                 /*
                 Button("New File") {
                     createNewFile()
-                } */
+                }
+                */
+                Spacer()
+                if let fileName = selectedURL?.lastPathComponent {
+                    Text(fileName)
+                        .lineLimit(1)
+                }
+                Spacer()
                 HStack {
                     Toggle("", isOn: $isEditing)
                         .disabled(selectedURL == nil)


### PR DESCRIPTION
## Summary
- show the opened file's name between the Open File button and the edit toggle

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_6841ab1611c88323a5d715bacb35637c