### PR TITLE
Apply dark mode and editing border

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -21,17 +21,10 @@ struct ContentView: View {
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
-                Button("Open File") {
-                    showPicker = true
+                Button(action: { showPicker = true }) {
+                    Image(systemName: "folder.open")
                 }
-                /*
-                Button("New File") {
-                    createNewFile()
-                } */
-                HStack {
-                    Toggle("", isOn: $isEditing)
-                        .disabled(selectedURL == nil)
-                }
+                Spacer()
                 if isEditing {
                     Button("Help") {
                         withAnimation {
@@ -39,12 +32,11 @@ struct ContentView: View {
                         }
                     }
                 }
-                /*
-                Button("Save") {
-                    saveText()
+                Toggle(isOn: $isEditing) {
+                    Image(systemName: "pencil")
                 }
                 .disabled(selectedURL == nil)
-                */
+                .padding(.leading, 8)
             }
             .padding()
 
@@ -54,6 +46,10 @@ struct ContentView: View {
                         TextEditor(text: $text)
                             .frame(width: showHelp ? geo.size.width * 2/3 : geo.size.width)
                             .border(Color.gray)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.yellow, lineWidth: 1)
+                            )
                         if showHelp {
                             ScrollView {
                                 Text(helpText)
@@ -86,6 +82,9 @@ struct ContentView: View {
                 .padding()
             }
         }
+        .padding()
+        .background(Color.black)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
         .sheet(isPresented: $showPicker) {
             FilePicker { url in
                 selectedURL = url

--- a/MyApp.swift
+++ b/MyApp.swift
@@ -5,6 +5,7 @@ struct MyApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .preferredColorScheme(.dark)
         }
     }
 }


### PR DESCRIPTION
## Summary
- force dark color scheme
- show yellow border only around the text editor while editing
- use an SF symbol for the Open File button and move the edit toggle to the far right

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_6841ab6c37548323a268135d3ac41d26